### PR TITLE
bugfix: updated check.yaml from 6.6 to 6.8

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -27,7 +27,7 @@ jobs:
         package:
         - kernel_linux_6_1_rockchip.kernel
         - kernel_linux_6_6_rockchip.kernel
-        - kernel_linux_6_6_pinetab.kernel
+        - kernel_linux_6_8_pinetab.kernel
         - uBootRock64
         - uBootRockPro64
         - uBootPinebookPro

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -59,7 +59,7 @@ jobs:
           extra-platforms = aarch64-linux
     - uses: cachix/cachix-action@v12
       with:
-        name: nabam-nixos-rockchip
+        name: pinetab2th
     - run: |
         nix build -L -j4 .#${{ matrix.package }}
 
@@ -85,7 +85,7 @@ jobs:
           extra-platforms = aarch64-linux
     - uses: cachix/cachix-action@v12
       with:
-        name: nabam-nixos-rockchip
+        name: pinetab2th
     - working-directory: ./example
       run: |
         nix build -L -j4 --accept-flake-config --override-input rockchip ..

--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -51,7 +51,7 @@ jobs:
           extra-platforms = aarch64-linux
     - uses: cachix/cachix-action@v12
       with:
-        name: nabam-nixos-rockchip
+        name: pinetab2th
         authToken: '${{ secrets.CACHIX_TOKEN }}'
     - run: |
         nix build -L -j4 .#${{ matrix.package }}
@@ -72,7 +72,7 @@ jobs:
           extra-platforms = aarch64-linux
     - uses: cachix/cachix-action@v12
       with:
-        name: nabam-nixos-rockchip
+        name: pinetab2th
         authToken: '${{ secrets.CACHIX_TOKEN }}'
         pushFilter: '(-nixos-sd-image-.*)\.img$|-ext4-fs\.img$'
     - working-directory: ./example
@@ -150,7 +150,7 @@ jobs:
           extra-platforms = aarch64-linux
     - uses: cachix/cachix-action@v12
       with:
-        name: nabam-nixos-rockchip
+        name: pinetab2th
         authToken: '${{ secrets.CACHIX_TOKEN }}'
         pushFilter: '(-nixos-sd-image-.*)\.img$|-ext4-fs\.img$'
     - run: |

--- a/example/flake.lock
+++ b/example/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1710695816,
-        "narHash": "sha256-3Eh7fhEID17pv9ZxrPwCLfqXnYP006RKzSs0JptsN84=",
+        "lastModified": 1716633019,
+        "narHash": "sha256-xim1b5/HZYbWaZKyI7cn9TJCM6ewNVZnesRr00mXeS4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "614b4613980a522ba49f0d194531beddbb7220d3",
+        "rev": "9d29cd266cebf80234c98dd0b87256b6be0af44e",
         "type": "github"
       },
       "original": {
@@ -18,11 +18,11 @@
     },
     "nixpkgsStable": {
       "locked": {
-        "lastModified": 1710695816,
-        "narHash": "sha256-3Eh7fhEID17pv9ZxrPwCLfqXnYP006RKzSs0JptsN84=",
+        "lastModified": 1716633019,
+        "narHash": "sha256-xim1b5/HZYbWaZKyI7cn9TJCM6ewNVZnesRr00mXeS4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "614b4613980a522ba49f0d194531beddbb7220d3",
+        "rev": "9d29cd266cebf80234c98dd0b87256b6be0af44e",
         "type": "github"
       },
       "original": {
@@ -34,11 +34,11 @@
     },
     "nixpkgsUnstable": {
       "locked": {
-        "lastModified": 1710631334,
-        "narHash": "sha256-rL5LSYd85kplL5othxK5lmAtjyMOBg390sGBTb3LRMM=",
+        "lastModified": 1716509168,
+        "narHash": "sha256-4zSIhSRRIoEBwjbPm3YiGtbd8HDWzFxJjw5DYSDy1n8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c75037bbf9093a2acb617804ee46320d6d1fea5a",
+        "rev": "bfb7a882678e518398ce9a31a881538679f6f092",
         "type": "github"
       },
       "original": {
@@ -55,11 +55,11 @@
         "utils": "utils"
       },
       "locked": {
-        "lastModified": 1710785499,
-        "narHash": "sha256-EaYf55jcUzYSNjuybpIPVl5groK7ioeTEe67g+yNGTo=",
+        "lastModified": 1716833591,
+        "narHash": "sha256-GDTi4ZWuzGPsQhi9jifj4dLcw4w2cORBFexPRuzAGs8=",
         "owner": "nabam",
         "repo": "nixos-rockchip",
-        "rev": "8cde7a8858142511d50ebe11f319418adcb86928",
+        "rev": "de35782940137e3e85e857196e15ea17ff9a3b69",
         "type": "github"
       },
       "original": {

--- a/example/flake.nix
+++ b/example/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "Build example NixOS image for Quartz64A";
+  description = "Build example NixOS image for PineTab2";
 
   inputs = {
     utils.url = "github:numtide/flake-utils";
@@ -10,9 +10,9 @@
 
   # Use cache with packages from nabam/nixos-rockchip CI.
   nixConfig = {
-    extra-substituters = [ "https://nabam-nixos-rockchip.cachix.org" ];
+    extra-substituters = [ "https://pinetab2th.cachix.org" ];
     extra-trusted-public-keys = [
-      "nabam-nixos-rockchip.cachix.org-1:BQDltcnV8GS/G86tdvjLwLFz1WeFqSk7O9yl+DR0AVM"
+      "pinetab2th.cachix.org-1:HfHv9nUkkyt3DlhR04CakY7yBzhQvb6CejsbAS1/44s="
     ];
   };
 
@@ -29,9 +29,9 @@
             {
               # Use cross-compilation for uBoot and Kernel.
               rockchip.uBoot =
-                inputs.rockchip.packages.${buildPlatform}.uBootQuartz64A;
+                inputs.rockchip.packages.${buildPlatform}.uBootPineTab2;
               boot.kernelPackages =
-                inputs.rockchip.legacyPackages.${buildPlatform}.kernel_linux_6_6_rockchip;
+                inputs.rockchip.legacyPackages.${buildPlatform}.kernel_linux_6_8_pinetab;
             }
 
             inputs.rockchip.nixosModules.noZFS # ZFS is broken on kernel from unstable

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgsStable": {
       "locked": {
-        "lastModified": 1710951922,
-        "narHash": "sha256-FOOBJ3DQenLpTNdxMHR2CpGZmYuctb92gF0lpiirZ30=",
+        "lastModified": 1716633019,
+        "narHash": "sha256-xim1b5/HZYbWaZKyI7cn9TJCM6ewNVZnesRr00mXeS4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f091af045dff8347d66d186a62d42aceff159456",
+        "rev": "9d29cd266cebf80234c98dd0b87256b6be0af44e",
         "type": "github"
       },
       "original": {
@@ -18,11 +18,11 @@
     },
     "nixpkgsUnstable": {
       "locked": {
-        "lastModified": 1711001935,
-        "narHash": "sha256-URtGpHue7HHZK0mrHnSf8wJ6OmMKYSsoLmJybrOLFSQ=",
+        "lastModified": 1716769173,
+        "narHash": "sha256-7EXDb5WBw+d004Agt+JHC/Oyh/KTUglOaQ4MNjBbo5w=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "20f77aa09916374aa3141cbc605c955626762c9a",
+        "rev": "9ca3f649614213b2aaf5f1e16ec06952fe4c2632",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
otherwise checks.yaml workflow doesnt complete successfully

```
Run nix build -L -j4 .#kernel_linux_6_6_pinetab.kernel
error: flake 'git+file:///home/runner/work/nixos-rockchip/nixos-rockchip?shallow=1' does not provide attribute 'packages.x86_64-linux.kernel_linux_6_6_pinetab.kernel', 'legacyPackages.x86_64-linux.kernel_linux_6_6_pinetab.kernel' or 'kernel_linux_6_6_pinetab.kernel'
       Did you mean kernel_linux_6_8_pinetab?
```